### PR TITLE
Fix: Broken Unit tests

### DIFF
--- a/internal/backend_test.go
+++ b/internal/backend_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestPathRoutingAndSupportedOperations(t *testing.T) {
 	b, err := BackendFactory(context.Background(), &logical.BackendConfig{})
-	require.NoError(t, err)
+	require.NoError(t, err, "failed to create backend")
 
 	storage := &logical.InmemStorage{}
 
@@ -66,7 +66,7 @@ func TestPathRoutingAndSupportedOperations(t *testing.T) {
 				// sign/ requires request data
 				if strings.HasPrefix(tt.path, "sign/") {
 					req.Data = map[string]interface{}{
-						"sign": "7d15728d30727d67a3257e6bbd4724c4d31f830f017fd0e0d2d802c14bdf408d",
+						"sign": strings.ToLower("7d15728d30727d67a3257e6bbd4724c4d31f830f017fd0e0d2d802c14bdf408d"),
 					}
 				}
 

--- a/internal/callbacks.go
+++ b/internal/callbacks.go
@@ -135,7 +135,7 @@ func generateAccount() (*hexAccountData, error) {
 }
 
 func rawKeyToHexAccountData(rawKey string) (*hexAccountData, error) {
-	key, err := geCrypto.HexToECDSA(rawKey)
+	key, err := geCrypto.HexToECDSA(strings.TrimPrefix(rawKey, "0x"))
 	if err != nil {
 		return nil, err
 	}
@@ -151,13 +151,13 @@ func keyToHexAccountData(key *ecdsa.PrivateKey) (*hexAccountData, error) {
 	}
 	addr := geCrypto.PubkeyToAddress(*publicKeyECDSA)
 
-	var hexKey = hexutil.Encode(geCrypto.FromECDSA(key))
+	var hexKey = strings.TrimPrefix(hexutil.Encode(geCrypto.FromECDSA(key)), "0x")
 	if hexKey == "" {
 		return nil, errors.New("unable to encode private key to hex string")
 	}
 
 	return &hexAccountData{
-		HexAddress: addr.String(),
+		HexAddress: strings.TrimPrefix(addr.String(), "0x"),
 		HexKey:     hexKey,
 	}, nil
 }
@@ -216,7 +216,7 @@ func (b *backend) sign(ctx context.Context, req *logical.Request, d *framework.F
 
 	b.Logger().Info("retrieved account for signing")
 
-	key, err := geCrypto.HexToECDSA(*hexKey)
+	key, err := geCrypto.HexToECDSA(strings.TrimPrefix(*hexKey, "0x"))
 	if err != nil {
 		return nil, err
 	}
@@ -228,7 +228,7 @@ func (b *backend) sign(ctx context.Context, req *logical.Request, d *framework.F
 
 	return &logical.Response{
 		Data: map[string]interface{}{
-			"sig": hex.EncodeToString(sig),
+			"sig": strings.TrimPrefix(hex.EncodeToString(sig), "0x"),
 		},
 	}, nil
 }


### PR DESCRIPTION
Changes include
1. Fix all broken unit tests due to library change from `quorum-go-utils` to `go-ethereum`. The main reason that tests were breaking is that hex strings were being stripped of `0x` prefixes as part of Consensys `quorum-go-utils` but not `go-ethereum`. This behavior though expected, does not satisfy functionality. Thus the same is done manually at all relevant sites.
2. Ensure all string comparisons are lower case otherwise ordinal comparison will fail. Stringization of bytes is case insensitive but ordinal comparison has no simple way of doing case insensitive comparison.
3. Add short trace messages to test assertions sites. This helps pin down test site failure much faster.
4. Improve `Makefile` to run `govulncheck` and ensure all targets are run using default `make` command.