### PR TITLE
Fix unit test coverage for additional error handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,4 +138,3 @@ help:
 	@echo "  go-vulncheck - Run vulnerability scanner"
 	@echo "  tools      - Install required tools"
 	@echo "  help       - Show this help message"
-

--- a/internal/callbacks.go
+++ b/internal/callbacks.go
@@ -82,12 +82,12 @@ func validateHexString(s string) bool {
 //   - bool: true if the account exists, false otherwise
 //   - error: Any error encountered during the existence check
 func (b *backend) accountExistenceCheck(ctx context.Context, req *logical.Request, _ *framework.FieldData) (bool, error) {
-	b.Logger().Info("performing existence check")
-
 	// Validate request using helper function
 	if err := validateRequest(ctx, req); err != nil {
 		return false, err
 	}
+
+	b.Logger().Info("performing existence check")
 
 	storageEntry, err := req.Storage.Get(ctx, req.Path)
 	if err != nil {
@@ -114,12 +114,12 @@ func (b *backend) accountExistenceCheck(ctx context.Context, req *logical.Reques
 //   - *logical.Response: Response containing the account address, or nil if not found
 //   - error: Any error encountered during the read operation
 func (b *backend) readAccount(ctx context.Context, req *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
-	b.Logger().Info("reading account", "path", req.Path)
-
 	// Validate inputs
 	if err := validateRequest(ctx, req); err != nil {
 		return nil, err
 	}
+
+	b.Logger().Info("reading account", "path", req.Path)
 
 	storageEntry, err := req.Storage.Get(ctx, req.Path)
 	if err != nil {
@@ -402,12 +402,12 @@ func keyToHexAccountData(key *ecdsa.PrivateKey) (*hexAccountData, error) {
 //   - *logical.Response: Response containing the list of account IDs
 //   - error: Any error encountered during the list operation
 func (b *backend) listAccountIDs(ctx context.Context, req *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
-	b.Logger().Info("listing account IDs", "path", req.Path)
-
 	// Validate inputs
 	if err := validateRequest(ctx, req); err != nil {
 		return nil, err
 	}
+
+	b.Logger().Info("listing account IDs", "path", req.Path)
 
 	ids, err := req.Storage.List(ctx, req.Path)
 	if err != nil {
@@ -441,8 +441,6 @@ func (b *backend) listAccountIDs(ctx context.Context, req *logical.Request, _ *f
 //   - *logical.Response: Response containing the hex-encoded signature
 //   - error: Any error encountered during validation, key retrieval, or signing
 func (b *backend) sign(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	b.Logger().Info("signing some data", "path", req.Path)
-
 	// Validate inputs using helper function
 	if err := validateRequest(ctx, req); err != nil {
 		return nil, err
@@ -450,6 +448,8 @@ func (b *backend) sign(ctx context.Context, req *logical.Request, d *framework.F
 	if d == nil {
 		return nil, fmt.Errorf("field data cannot be nil")
 	}
+
+	b.Logger().Info("signing some data", "path", req.Path)
 
 	acctID, ok := d.GetOk("acctID")
 	if !ok {

--- a/internal/callbacks_test.go
+++ b/internal/callbacks_test.go
@@ -297,3 +297,631 @@ func TestSign(t *testing.T) {
 	require.NoError(t, err, "unexpected error from sign")
 	require.Equal(t, wantSig, resp.Data["sig"], "signature does not match expected value")
 }
+
+// Additional test cases for better coverage
+
+func TestAccountExistenceCheck_ErrorCases(t *testing.T) {
+	b := createBackend(t)
+
+	t.Run("nil context", func(t *testing.T) {
+		req := &logical.Request{
+			Storage: &logical.InmemStorage{},
+			Path:    "accounts/test",
+		}
+		_, err := b.accountExistenceCheck(nil, req, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("nil request", func(t *testing.T) {
+		_, err := b.accountExistenceCheck(context.Background(), nil, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("nil storage", func(t *testing.T) {
+		req := &logical.Request{
+			Storage: nil,
+			Path:    "accounts/test",
+		}
+		_, err := b.accountExistenceCheck(context.Background(), req, nil)
+		require.Error(t, err)
+	})
+}
+
+func TestReadAccount_ErrorCases(t *testing.T) {
+	b := createBackend(t)
+
+	t.Run("nil context", func(t *testing.T) {
+		req := &logical.Request{
+			Storage: &logical.InmemStorage{},
+			Path:    "accounts/test",
+		}
+		_, err := b.readAccount(nil, req, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("nil request", func(t *testing.T) {
+		_, err := b.readAccount(context.Background(), nil, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("nil storage", func(t *testing.T) {
+		req := &logical.Request{
+			Storage: nil,
+			Path:    "accounts/test",
+		}
+		_, err := b.readAccount(context.Background(), req, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("invalid json data", func(t *testing.T) {
+		storage := &logical.InmemStorage{}
+		entry := &logical.StorageEntry{
+			Key:   "accounts/test",
+			Value: []byte("invalid json"),
+		}
+		err := storage.Put(context.Background(), entry)
+		require.NoError(t, err)
+
+		req := &logical.Request{
+			Storage: storage,
+			Path:    "accounts/test",
+		}
+		_, err = b.readAccount(context.Background(), req, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("empty address", func(t *testing.T) {
+		storage := &logical.InmemStorage{}
+		entry, err := logical.StorageEntryJSON("accounts/test", "")
+		require.NoError(t, err)
+		err = storage.Put(context.Background(), entry)
+		require.NoError(t, err)
+
+		req := &logical.Request{
+			Storage: storage,
+			Path:    "accounts/test",
+		}
+		_, err = b.readAccount(context.Background(), req, nil)
+		require.Error(t, err)
+	})
+}
+
+func TestCreateAccount_ErrorCases(t *testing.T) {
+	b := createBackend(t)
+
+	t.Run("nil context", func(t *testing.T) {
+		req := &logical.Request{
+			Storage: &logical.InmemStorage{},
+			Path:    "accounts/test",
+		}
+		d := &framework.FieldData{
+			Raw: map[string]interface{}{
+				"acctID": "test",
+			},
+			Schema: map[string]*framework.FieldSchema{
+				"acctID": {Type: framework.TypeString},
+			},
+		}
+		_, err := b.createAccount(nil, req, d)
+		require.Error(t, err)
+	})
+
+	t.Run("nil request", func(t *testing.T) {
+		d := &framework.FieldData{}
+		_, err := b.createAccount(context.Background(), nil, d)
+		require.Error(t, err)
+	})
+
+	t.Run("nil field data", func(t *testing.T) {
+		req := &logical.Request{
+			Storage: &logical.InmemStorage{},
+			Path:    "accounts/test",
+		}
+		_, err := b.createAccount(context.Background(), req, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("empty import key", func(t *testing.T) {
+		req := &logical.Request{
+			Storage: &logical.InmemStorage{},
+			Path:    "accounts/test",
+		}
+		d := &framework.FieldData{
+			Raw: map[string]interface{}{
+				"acctID": "test",
+				"import": "   ",
+			},
+			Schema: map[string]*framework.FieldSchema{
+				"acctID": {Type: framework.TypeString},
+				"import": {Type: framework.TypeString},
+			},
+		}
+		_, err := b.createAccount(context.Background(), req, d)
+		require.Error(t, err)
+	})
+
+	t.Run("invalid import key", func(t *testing.T) {
+		req := &logical.Request{
+			Storage: &logical.InmemStorage{},
+			Path:    "accounts/test",
+		}
+		d := &framework.FieldData{
+			Raw: map[string]interface{}{
+				"acctID": "test",
+				"import": "invalid",
+			},
+			Schema: map[string]*framework.FieldSchema{
+				"acctID": {Type: framework.TypeString},
+				"import": {Type: framework.TypeString},
+			},
+		}
+		_, err := b.createAccount(context.Background(), req, d)
+		require.Error(t, err)
+	})
+
+	t.Run("missing acctID", func(t *testing.T) {
+		req := &logical.Request{
+			Storage: &logical.InmemStorage{},
+			Path:    "accounts/test",
+		}
+		d := &framework.FieldData{
+			Raw: map[string]interface{}{},
+			Schema: map[string]*framework.FieldSchema{
+				"acctID": {Type: framework.TypeString},
+			},
+		}
+		_, err := b.createAccount(context.Background(), req, d)
+		require.Error(t, err)
+	})
+}
+
+func TestSign_ErrorCases(t *testing.T) {
+	b := createBackend(t)
+
+	t.Run("nil context", func(t *testing.T) {
+		req := &logical.Request{
+			Storage: &logical.InmemStorage{},
+			Path:    "sign/test",
+		}
+		d := &framework.FieldData{}
+		_, err := b.sign(nil, req, d)
+		require.Error(t, err)
+	})
+
+	t.Run("nil request", func(t *testing.T) {
+		d := &framework.FieldData{}
+		_, err := b.sign(context.Background(), nil, d)
+		require.Error(t, err)
+	})
+
+	t.Run("nil field data", func(t *testing.T) {
+		req := &logical.Request{
+			Storage: &logical.InmemStorage{},
+			Path:    "sign/test",
+		}
+		_, err := b.sign(context.Background(), req, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("missing acctID", func(t *testing.T) {
+		req := &logical.Request{
+			Storage: &logical.InmemStorage{},
+			Path:    "sign/test",
+		}
+		d := &framework.FieldData{
+			Raw: map[string]interface{}{
+				"sign": "deadbeef",
+			},
+			Schema: map[string]*framework.FieldSchema{
+				"sign": {Type: framework.TypeString},
+			},
+		}
+		_, err := b.sign(context.Background(), req, d)
+		require.Error(t, err)
+	})
+
+	t.Run("missing sign data", func(t *testing.T) {
+		req := &logical.Request{
+			Storage: &logical.InmemStorage{},
+			Path:    "sign/test",
+		}
+		d := &framework.FieldData{
+			Raw: map[string]interface{}{
+				"acctID": "test",
+			},
+			Schema: map[string]*framework.FieldSchema{
+				"acctID": {Type: framework.TypeString},
+				"sign":   {Type: framework.TypeString},
+			},
+		}
+		_, err := b.sign(context.Background(), req, d)
+		require.Error(t, err)
+	})
+
+	t.Run("empty sign data", func(t *testing.T) {
+		req := &logical.Request{
+			Storage: &logical.InmemStorage{},
+			Path:    "sign/test",
+		}
+		d := &framework.FieldData{
+			Raw: map[string]interface{}{
+				"acctID": "test",
+				"sign":   "   ",
+			},
+			Schema: map[string]*framework.FieldSchema{
+				"acctID": {Type: framework.TypeString},
+				"sign":   {Type: framework.TypeString},
+			},
+		}
+		_, err := b.sign(context.Background(), req, d)
+		require.Error(t, err)
+	})
+
+	t.Run("only 0x prefix", func(t *testing.T) {
+		req := &logical.Request{
+			Storage: &logical.InmemStorage{},
+			Path:    "sign/test",
+		}
+		d := &framework.FieldData{
+			Raw: map[string]interface{}{
+				"acctID": "test",
+				"sign":   "0x",
+			},
+			Schema: map[string]*framework.FieldSchema{
+				"acctID": {Type: framework.TypeString},
+				"sign":   {Type: framework.TypeString},
+			},
+		}
+		_, err := b.sign(context.Background(), req, d)
+		require.Error(t, err)
+	})
+
+	t.Run("odd length hex", func(t *testing.T) {
+		req := &logical.Request{
+			Storage: &logical.InmemStorage{},
+			Path:    "sign/test",
+		}
+		d := &framework.FieldData{
+			Raw: map[string]interface{}{
+				"acctID": "test",
+				"sign":   "abc",
+			},
+			Schema: map[string]*framework.FieldSchema{
+				"acctID": {Type: framework.TypeString},
+				"sign":   {Type: framework.TypeString},
+			},
+		}
+		_, err := b.sign(context.Background(), req, d)
+		require.Error(t, err)
+	})
+
+	t.Run("invalid hex characters", func(t *testing.T) {
+		req := &logical.Request{
+			Storage: &logical.InmemStorage{},
+			Path:    "sign/test",
+		}
+		d := &framework.FieldData{
+			Raw: map[string]interface{}{
+				"acctID": "test",
+				"sign":   "gggggggg",
+			},
+			Schema: map[string]*framework.FieldSchema{
+				"acctID": {Type: framework.TypeString},
+				"sign":   {Type: framework.TypeString},
+			},
+		}
+		_, err := b.sign(context.Background(), req, d)
+		require.Error(t, err)
+	})
+
+	t.Run("account not found", func(t *testing.T) {
+		req := &logical.Request{
+			Storage: &logical.InmemStorage{},
+			Path:    "sign/test",
+		}
+		d := &framework.FieldData{
+			Raw: map[string]interface{}{
+				"acctID": "test",
+				"sign":   "deadbeef",
+			},
+			Schema: map[string]*framework.FieldSchema{
+				"acctID": {Type: framework.TypeString},
+				"sign":   {Type: framework.TypeString},
+			},
+		}
+		_, err := b.sign(context.Background(), req, d)
+		require.Error(t, err)
+	})
+
+	t.Run("invalid key in storage", func(t *testing.T) {
+		storage := &logical.InmemStorage{}
+		entry, err := logical.StorageEntryJSON("keys/test", "invalid")
+		require.NoError(t, err)
+		err = storage.Put(context.Background(), entry)
+		require.NoError(t, err)
+
+		req := &logical.Request{
+			Storage: storage,
+			Path:    "sign/test",
+		}
+		d := &framework.FieldData{
+			Raw: map[string]interface{}{
+				"acctID": "test",
+				"sign":   "deadbeef",
+			},
+			Schema: map[string]*framework.FieldSchema{
+				"acctID": {Type: framework.TypeString},
+				"sign":   {Type: framework.TypeString},
+			},
+		}
+		_, err = b.sign(context.Background(), req, d)
+		require.Error(t, err)
+	})
+
+	t.Run("empty key in storage", func(t *testing.T) {
+		storage := &logical.InmemStorage{}
+		entry, err := logical.StorageEntryJSON("keys/test", "")
+		require.NoError(t, err)
+		err = storage.Put(context.Background(), entry)
+		require.NoError(t, err)
+
+		req := &logical.Request{
+			Storage: storage,
+			Path:    "sign/test",
+		}
+		d := &framework.FieldData{
+			Raw: map[string]interface{}{
+				"acctID": "test",
+				"sign":   "deadbeef",
+			},
+			Schema: map[string]*framework.FieldSchema{
+				"acctID": {Type: framework.TypeString},
+				"sign":   {Type: framework.TypeString},
+			},
+		}
+		_, err = b.sign(context.Background(), req, d)
+		require.Error(t, err)
+	})
+}
+
+func TestListAccountIDs_ErrorCases(t *testing.T) {
+	b := createBackend(t)
+
+	t.Run("nil context", func(t *testing.T) {
+		req := &logical.Request{
+			Storage: &logical.InmemStorage{},
+			Path:    "accounts/",
+		}
+		_, err := b.listAccountIDs(nil, req, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("nil request", func(t *testing.T) {
+		_, err := b.listAccountIDs(context.Background(), nil, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("nil storage", func(t *testing.T) {
+		req := &logical.Request{
+			Storage: nil,
+			Path:    "accounts/",
+		}
+		_, err := b.listAccountIDs(context.Background(), req, nil)
+		require.Error(t, err)
+	})
+}
+
+func TestGenerateAccount(t *testing.T) {
+	accountData, err := generateAccount()
+	require.NoError(t, err)
+	require.NotNil(t, accountData)
+	require.NotEmpty(t, accountData.HexAddress)
+	require.NotEmpty(t, accountData.HexKey)
+	require.Len(t, accountData.HexKey, EthereumPrivateKeyLength)
+}
+
+func TestRawKeyToHexAccountData_ErrorCases(t *testing.T) {
+	tests := map[string]struct {
+		input   string
+		wantErr bool
+	}{
+		"empty string": {
+			input:   "",
+			wantErr: true,
+		},
+		"whitespace only": {
+			input:   "   ",
+			wantErr: true,
+		},
+		"only 0x prefix": {
+			input:   "0x",
+			wantErr: true,
+		},
+		"too short": {
+			input:   "abc123",
+			wantErr: true,
+		},
+		"too long": {
+			input:   "a0379af19f0b55b0f384f83c95f668ba600b78f487f6414f2d22339273891eeca0379af19f0b55b0f384f83c95f668ba600b78f487f6414f2d22339273891eec",
+			wantErr: true,
+		},
+		"invalid hex characters": {
+			input:   "z0379af19f0b55b0f384f83c95f668ba600b78f487f6414f2d22339273891eec",
+			wantErr: true,
+		},
+		"valid key without 0x": {
+			input:   "a0379af19f0b55b0f384f83c95f668ba600b78f487f6414f2d22339273891eec",
+			wantErr: false,
+		},
+		"valid key with 0x": {
+			input:   "0xa0379af19f0b55b0f384f83c95f668ba600b78f487f6414f2d22339273891eec",
+			wantErr: false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			result, err := rawKeyToHexAccountData(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Nil(t, result)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, result)
+			}
+		})
+	}
+}
+
+func TestKeyToHexAccountData_ErrorCases(t *testing.T) {
+	t.Run("nil key", func(t *testing.T) {
+		result, err := keyToHexAccountData(nil)
+		require.Error(t, err)
+		require.Nil(t, result)
+	})
+
+	t.Run("valid key", func(t *testing.T) {
+		key, err := geCrypto.GenerateKey()
+		require.NoError(t, err)
+
+		result, err := keyToHexAccountData(key)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.NotEmpty(t, result.HexAddress)
+		require.NotEmpty(t, result.HexKey)
+	})
+}
+
+func TestValidateRequest(t *testing.T) {
+	tests := map[string]struct {
+		ctx     context.Context
+		req     *logical.Request
+		wantErr bool
+	}{
+		"valid request": {
+			ctx: context.Background(),
+			req: &logical.Request{
+				Storage: &logical.InmemStorage{},
+			},
+			wantErr: false,
+		},
+		"nil context": {
+			ctx: nil,
+			req: &logical.Request{
+				Storage: &logical.InmemStorage{},
+			},
+			wantErr: true,
+		},
+		"nil request": {
+			ctx:     context.Background(),
+			req:     nil,
+			wantErr: true,
+		},
+		"nil storage": {
+			ctx: context.Background(),
+			req: &logical.Request{
+				Storage: nil,
+			},
+			wantErr: true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := validateRequest(tt.ctx, tt.req)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateHexString(t *testing.T) {
+	tests := map[string]struct {
+		input string
+		want  bool
+	}{
+		"valid hex lowercase":    {input: "deadbeef", want: true},
+		"valid hex uppercase":    {input: "DEADBEEF", want: true},
+		"valid hex mixed":        {input: "DeAdBeEf", want: true},
+		"valid hex with numbers": {input: "a1b2c3d4", want: true},
+		"empty string":           {input: "", want: true},
+		"invalid with g":         {input: "deadbeeg", want: false},
+		"invalid with space":     {input: "dead beef", want: false},
+		"invalid with 0x":        {input: "0xdeadbeef", want: false},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := validateHexString(tt.input)
+			require.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func TestCreateAccount_WithHexPrefix(t *testing.T) {
+	b := createBackend(t)
+
+	storage := &logical.InmemStorage{}
+
+	toImport := "0xa0379af19f0b55b0f384f83c95f668ba600b78f487f6414f2d22339273891eec"
+	wantAddr := strings.ToLower("4d6d744b6da435b5bbdde2526dc20e9a41cb72e5")
+
+	req := &logical.Request{
+		Storage: storage,
+		Path:    "accounts/myAcct",
+	}
+
+	d := &framework.FieldData{
+		Raw: map[string]interface{}{
+			"acctID": "myAcct",
+			"import": toImport,
+		},
+		Schema: map[string]*framework.FieldSchema{
+			"acctID": {Type: framework.TypeString},
+			"import": {Type: framework.TypeString},
+		},
+	}
+
+	resp, err := b.createAccount(context.Background(), req, d)
+	require.NoError(t, err)
+	require.Equal(t, wantAddr, strings.ToLower(resp.Data["addr"].(string)))
+}
+
+func TestSign_WithHexPrefix(t *testing.T) {
+	b := createBackend(t)
+
+	key := "a0379af19f0b55b0f384f83c95f668ba600b78f487f6414f2d22339273891eec"
+	toSign := "0xbc4c915d69896b198f0292a72373a2bdcd0d52bccbfcec11d9c84c0fff71b0bc"
+	wantSig := "f68df2227e39c9ba87baea5966f0c502b038031b10a39e96a721cd270700362d54bae75dcf035a180c17a3a8cf760bfa91a0a41969c0a1630ba6d20e06aa1a8501"
+
+	storage := &logical.InmemStorage{}
+
+	entry, err := logical.StorageEntryJSON("keys/myAcct", key)
+	require.NoError(t, err)
+
+	err = storage.Put(context.Background(), entry)
+	require.NoError(t, err)
+
+	req := &logical.Request{
+		Storage: storage,
+		Path:    "sign/myAcct",
+	}
+
+	d := &framework.FieldData{
+		Raw: map[string]interface{}{
+			"acctID": "myAcct",
+			"sign":   toSign,
+		},
+		Schema: map[string]*framework.FieldSchema{
+			"acctID": {Type: framework.TypeString},
+			"sign":   {Type: framework.TypeString},
+		},
+	}
+
+	resp, err := b.sign(context.Background(), req, d)
+	require.NoError(t, err)
+	require.Equal(t, wantSig, resp.Data["sig"])
+}


### PR DESCRIPTION
## fix security issues and test failures

- Address gosec findings across the codebase (input validation, resource handling, crypto usage)
- Fix failing unit tests and race conditions; restore test coverage thresholds
- Update `Makefile` targets (`go-sec`, `test`) to reflect fixes
- Tidy dependencies in `go.mod`/`go.sum`
- Minor refactors and additional unit tests for edge cases

## Evidence

- Run `make` against `dev` target to run ALL checks.
- Run `make` against `default` target to run a subset of pre-deploy checks.

<img width="2338" height="1208" alt="CleanShot 2025-11-04 at 08 20 00" src="https://github.com/user-attachments/assets/d7f253c9-2cf1-4655-99fc-78afe5cfe196" />
